### PR TITLE
Change default parameters request

### DIFF
--- a/lib/amazon_ssa_support/ssa_bucket.rb
+++ b/lib/amazon_ssa_support/ssa_bucket.rb
@@ -3,10 +3,10 @@ require_relative 'ssa_common'
 module AmazonSsaSupport
   module SsaBucket
     def self.get(arg_hash)
-      raise ArgumentError, "ssa_bucket must be specified." if arg_hash[:ssa_bucket].nil?
+      raise ArgumentError, "Bucket and region must be specified." unless arg_hash[:ssa_bucket] && arg_hash[:region]
 
       ssa_bucket_name = arg_hash[:ssa_bucket]
-      s3              = arg_hash[:s3] || Aws::S3::Resource.new(region: DEFAULT_REGION)
+      s3              = arg_hash[:s3] || Aws::S3::Resource.new(region: arg_hash[:region])
 
       if (ssa_bucket = s3.bucket(ssa_bucket_name)).exists?
         $log.debug("#{name}.#{__method__}: Found reply bucket #{ssa_bucket_name}")

--- a/lib/amazon_ssa_support/ssa_common.rb
+++ b/lib/amazon_ssa_support/ssa_common.rb
@@ -1,6 +1,5 @@
 # Constants and methods
 module AmazonSsaSupport
-  DEFAULT_REGION             = 'us-west-2'.freeze
   DEFAULT_HEARTBEAT_PREFIX   = 'extract/heartbeart/'.freeze
   DEFAULT_HEARTBEAT_INTERVAL = 120
   DEFAULT_REPLY_PREFIX       = 'extract/queue-reply/'.freeze

--- a/lib/amazon_ssa_support/ssa_heartbeat.rb
+++ b/lib/amazon_ssa_support/ssa_heartbeat.rb
@@ -10,10 +10,10 @@ module AmazonSsaSupport
     attr_reader :heartbeat_thread, :heartbeat_interval
 
     def initialize(args)
-      raise ArgumentError, "extractor_id must be specified" if args[:extractor_id].nil?
+      raise ArgumentError, "Region must be specified" if args[:region].nil?
 
       @extractor_id       = args[:extractor_id]
-      @region             = args[:region] || 'us-west-2'
+      @region             = args[:region]
       @s3                 = args[:s3] || Aws::S3::Resource.new(region: @region)
       @ssa_bucket         = SsaBucket.get(args)
       @heartbeat_prefix   = args[:heartbeat_prefix]

--- a/lib/amazon_ssa_support/ssa_queue.rb
+++ b/lib/amazon_ssa_support/ssa_queue.rb
@@ -12,13 +12,13 @@ module AmazonSsaSupport
     def initialize(args)
       @extractor_id       = args[:extractor_id]
       @ssa_bucket_name    = args[:ssa_bucket]
-      @ssa_region         = args[:region] || DEFAULT_REGION
+      @ssa_region         = args[:region]
       @request_queue_name = args[:request_queue] || DEFAULT_REQUEST_QUEUE
       @reply_queue_name   = args[:reply_queue] || DEFAULT_REPLY_QUEUE
       @reply_prefix       = args[:reply_prefix] || DEFAULT_REPLY_PREFIX
 
-      unless ssa_bucket_name && extractor_id
-        raise ArgumentError, "extractor_id & ssa_bucket_name must have to be specified."
+      unless ssa_bucket_name && ssa_region
+        raise ArgumentError, "bucket_name & region must have to be specified."
       end
 
       $log.debug("#{self.class.name}: request_queue_name = #{@request_queue_name}")

--- a/lib/amazon_ssa_support/ssa_queue.rb
+++ b/lib/amazon_ssa_support/ssa_queue.rb
@@ -18,7 +18,7 @@ module AmazonSsaSupport
       @reply_prefix       = args[:reply_prefix] || DEFAULT_REPLY_PREFIX
 
       unless ssa_bucket_name && ssa_region
-        raise ArgumentError, "bucket_name & region must have to be specified."
+        raise ArgumentError, "bucket & region must be specified."
       end
 
       $log.debug("#{self.class.name}: request_queue_name = #{@request_queue_name}")

--- a/lib/amazon_ssa_support/ssa_queue_extractor.rb
+++ b/lib/amazon_ssa_support/ssa_queue_extractor.rb
@@ -10,10 +10,10 @@ module AmazonSsaSupport
     attr_reader :my_instance, :ssaq
 
     def initialize(aws_args)
-      raise ArgumentError, "extractor_id must be specified." if aws_args[:extractor_id].nil?
+      raise ArgumentError, "Region must be specified." if aws_args[:region].nil?
       @aws_args     = aws_args
       @extractor_id = @aws_args[:extractor_id]
-      @region       = @aws_args[:region] || DEFAULT_REGION
+      @region       = @aws_args[:region]
 
       @ec2          = @aws_args[:ec2] || Aws::EC2::Resource.new(region: @region)
       @my_instance  = @ec2.instance(@extractor_id)

--- a/spec/ssa_bucket_spec.rb
+++ b/spec/ssa_bucket_spec.rb
@@ -10,7 +10,7 @@ describe AmazonSsaSupport::SsaBucket do
   end
 
   let(:args) do
-    { :ssa_bucket => 'bucket_name', :reply_prefix => 'miq_' }
+    { :ssa_bucket => 'bucket_name', :region => 'us-region' }
   end
 
   it "pass when have an get method" do
@@ -27,6 +27,11 @@ describe AmazonSsaSupport::SsaBucket do
 
   it "fails when ssa_bucket is not specified" do
     args.delete(:ssa_bucket)
+    expect { described_class.get(args) }.to raise_error(ArgumentError)
+  end
+
+  it "fails when region is not specified" do
+    args.delete(:region)
     expect { described_class.get(args) }.to raise_error(ArgumentError)
   end
 end

--- a/spec/ssa_heartbeat_spec.rb
+++ b/spec/ssa_heartbeat_spec.rb
@@ -14,7 +14,7 @@ describe AmazonSsaSupport::SsaHeartbeat do
   end
 
   let(:args) do
-    { :extractor_id       => 'instance_id',
+    { :region             => 'us-region',
       :ssa_bucket         => 'bucket',
       :reply_prefix       => 'rep-prefix',
       :heartbeat_prefix   => 'hb-prefix',
@@ -29,8 +29,8 @@ describe AmazonSsaSupport::SsaHeartbeat do
       expect { described_class.new }.to raise_error(ArgumentError)
     end
 
-    it "passes if an ArgumentError is raised when extractor_id is not specified." do
-      args.delete(:extractor_id)
+    it "passes if an ArgumentError is raised when region is not specified." do
+      args.delete(:region)
       expect { described_class.new(args) }.to raise_error(ArgumentError)
     end
 

--- a/spec/ssa_queue_spec.rb
+++ b/spec/ssa_queue_spec.rb
@@ -10,8 +10,8 @@ describe AmazonSsaSupport::SsaQueue do
   end
 
   let(:args) do
-    { :ssa_bucket   => 's3_bucket',
-      :extractor_id => 'instance-id' }
+    { :ssa_bucket => 's3_bucket',
+      :region     => 'us-region' }
   end
 
   subject { described_class.new(args) }
@@ -21,8 +21,8 @@ describe AmazonSsaSupport::SsaQueue do
       expect { described_class.new }.to raise_error(ArgumentError)
     end
 
-    it "require extractor_id" do
-      args.delete(:extractor_id)
+    it "require region" do
+      args.delete(:region)
       expect { described_class.new(args) }.to raise_error(ArgumentError)
     end
 
@@ -45,10 +45,6 @@ describe AmazonSsaSupport::SsaQueue do
 
     it "require reply_prefix" do
       expect(subject.reply_prefix).to be_truthy
-    end
-
-    it "require extractor_id" do
-      expect(subject.extractor_id).to be_truthy
     end
 
     it "require ssa_region" do


### PR DESCRIPTION
The changes contain: 
1. Enable to initialize SsaQueue without extractor_id;
2. Change region as a must-have parameter;

https://github.com/ManageIQ/amazon_ssa_support/issues/3
https://github.com/ManageIQ/amazon_ssa_support/issues/6