### PR TITLE
Include manageiq-smartstate gem

### DIFF
--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "aws-sdk", "~>2.9.7"
   spec.add_dependency "manageiq-gems-pending", "~> 0"
+  spec.add_dependency "manageiq-smartstate", "~> 0.1"
 
   spec.add_development_dependency "bundler", "~> 1.13"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/amazon_ssa_support.rb
+++ b/lib/amazon_ssa_support.rb
@@ -1,3 +1,4 @@
+require 'manageiq-smartstate'
 require 'amazon_ssa_support/version'
 require 'amazon_ssa_support/ssa_common'
 require 'amazon_ssa_support/instance_metadata'


### PR DESCRIPTION
This gem needs the manageiq-smartstate gem which was recently split from
the manageiq-gems-pending repo.

@Fryguy please merge.

@roliveri @hsong-rh FYI.