### PR TITLE
Missing S3 Object Should Raise an Exception

### DIFF
--- a/lib/amazon_ssa_support/ssa_queue.rb
+++ b/lib/amazon_ssa_support/ssa_queue.rb
@@ -158,9 +158,8 @@ module AmazonSsaSupport
         s3_obj_name = @reply_prefix + req_id
         s3_obj = @reply_bucket.object(s3_obj_name)
         unless s3_obj.exists?
-          $log.warn("#{self.class.name}.#{__method__}: Reply object #{s3_obj_name} does not exist")
           msg.delete
-          return nil
+          raise "Reply object #{s3_obj_name} does not exist"
         end
         reply_data = YAML.safe_load(s3_obj.read)
         reply_data[:request_id] = req_id


### PR DESCRIPTION
When the Object containing the SSA response, as designated in the
SQS message, is missing from the S3 bucket, we should not simply
issue a warning message.  This should be considered an Exception -
waiting for the Object to show up is not going to do anyone any good.
This was encountered during testing by using an incorrect bucket name,
but if the bucket name were correct we would continue looking for the
object until the request timed out.

@hsong-rh and @roliveri please review and merge.  Thanks much.