### PR TITLE
Move extract tool to a proper bin file

### DIFF
--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -13,10 +13,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/ManageIQ/amazon_ssa_support"
   spec.license       = "MIT"
 
-  #spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-  #  f.match(%r{^(test|spec|features)/})
-  #end
-  spec.files         = Dir.glob("lib/**/*.rb")
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) } - %w[console setup]
+  spec.require_paths = ["lib"]
 
   spec.add_dependency "aws-sdk", "~>2.9.7"
   spec.add_dependency "manageiq-gems-pending", "~> 0"

--- a/bin/amazon_ssa_agent
+++ b/bin/amazon_ssa_agent
@@ -1,5 +1,7 @@
-require 'rubygems'
-require 'bundler/setup'
+#!/usr/bin/env ruby
+root_dir = File.expand_path("..", __dir__)
+Dir.chdir(root_dir) { require 'bundler/setup' }
+$LOAD_PATH << File.join(root_dir, "lib")
 
 require 'optparse'
 require 'log4r'


### PR DESCRIPTION
Move the script to a proper bin file, which greatly simplifies actually running the agent, since gem bin paths are on the $PATH

@roliveri Please review.