### PR TITLE
Don't raise an exception when reply object missing

### DIFF
--- a/lib/amazon_ssa_support/ssa_queue.rb
+++ b/lib/amazon_ssa_support/ssa_queue.rb
@@ -159,7 +159,8 @@ module AmazonSsaSupport
         s3_obj = @reply_bucket.object(s3_obj_name)
         unless s3_obj.exists?
           msg.delete
-          raise "Reply object #{s3_obj_name} does not exist"
+          $log.error("Reply object #{s3_obj_name} does not exist")
+          return nil
         end
         reply_data = YAML.load(s3_obj.get.body.read, safe: true)
         reply_data[:request_id] = req_id


### PR DESCRIPTION
When the reply object specified by a reply message on the SQS queue
is missing, simply log an error and go on to the next message (if any).
Raising an exception causes the processing to skip the rest of the messages.

This PR is required for the work to support AWS SSA.

@roliveri @hsong-rh please review and merge when appropriate.  Thanks!