### PR TITLE
Fix the gemspec to properly point to log_decorator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in amazon_ssa_support.gemspec
 gemspec
 
-gem "log_decorator", "~>0.1.0", :require => 'log_decorator'
-gem "manageiq-gems-pending", ">0", :require => 'manageiq-gems-pending', :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
-gem "manageiq-smartstate", "~>0.2.1", :require => 'manageiq-smartstate'
-gem "rake"
+gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
 
 group :test do
   gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"

--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) } - %w[console setup]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk", "~>2.9.7"
+  spec.add_dependency "aws-sdk",               "~>2.9.7"
+  spec.add_dependency "log_decorator",         "~> 0.1"
   spec.add_dependency "manageiq-gems-pending", "~> 0"
-  spec.add_dependency "manageiq-smartstate", "~> 0.2"
+  spec.add_dependency "manageiq-smartstate",   "~> 0.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
@hsong-rh @roliveri This will fix the broken ManageIQ master that was caused by #23.  For gems, the gemspec is the source of truth, and the Gemfile is only used in development to enhance it with things like the git based gems.