### PR TITLE
Replace ssa with smartstate in queue, bucket, snapshot and volume names

### DIFF
--- a/lib/amazon_ssa_support/miq_ec2_vm/miq_ec2_ebs_instance.rb
+++ b/lib/amazon_ssa_support/miq_ec2_vm/miq_ec2_ebs_instance.rb
@@ -19,9 +19,9 @@ module AmazonSsaSupport
 
     def create_snapshot(vol_id)
       _log.info("    Creating snapshot of instance volume #{vol_id}")
-      snap = @ec2.create_snapshot(volume_id: vol_id, description: "SSA extract snapshot for instance: #{@ec2_obj.id}")
+      snap = @ec2.create_snapshot(volume_id: vol_id, description: "Smartstate extract snapshot for instance: #{@ec2_obj.id}")
       snap.wait_until_completed
-      snap.create_tags(tags: [{key: 'Name', value: 'SSA extract snapshot'}])
+      snap.create_tags(tags: [{key: 'Name', value: 'Smartstate extract snapshot'}])
       _log.info("    Snapshot #{snap.id} of instance volume #{vol_id} created!")
       @snapshots << snap
       snap

--- a/lib/amazon_ssa_support/miq_ec2_vm/miq_ec2_ebs_vmbase.rb
+++ b/lib/amazon_ssa_support/miq_ec2_vm/miq_ec2_ebs_vmbase.rb
@@ -70,8 +70,8 @@ module AmazonSsaSupport
       sleep 2
       @ec2.client.wait_until(:volume_available, volume_ids: [volume.id])
 
-      volume.create_tags(tags: [{ key: 'Name', value: 'SSA extract volume'},
-                                { key: 'Description', value: "SSA extract volume for image: #{@ec2_obj.id}"}])
+      volume.create_tags(tags: [{ key: 'Name', value: 'Smartstate extract volume'},
+                                { key: 'Description', value: "Smartstate extract volume for image: #{@ec2_obj.id}"}])
 
       _log.info("    Volume #{volume.id} of snapshot #{snap_id} created!")
       @volumes << volume

--- a/lib/amazon_ssa_support/ssa_common.rb
+++ b/lib/amazon_ssa_support/ssa_common.rb
@@ -6,14 +6,14 @@ module AmazonSsaSupport
   DEFAULT_HEARTBEAT_PREFIX   = 'extract/heartbeat/'.freeze
   DEFAULT_HEARTBEAT_INTERVAL = 120
 
-  DEFAULT_REQUEST_QUEUE      = 'ssa_extract_request'.freeze
-  DEFAULT_REPLY_QUEUE        = 'ssa_extract_reply'.freeze
+  DEFAULT_REQUEST_QUEUE      = 'smartstate_extract_request'.freeze
+  DEFAULT_REPLY_QUEUE        = 'smartstate_extract_reply'.freeze
 
   DEFAULT_REPLY_PREFIX       = 'extract/queue-reply/'.freeze
   DEFAULT_LOG_PREFIX         = 'extract/logs/'.freeze
 
   DEFAULT_LOG_LEVEL          = 'INFO'.freeze
-  DEFAULT_BUCKET_PREFIX      = 'miq-ssa'.freeze
+  DEFAULT_BUCKET_PREFIX      = 'smartstate'.freeze
 
   DEFAULT_REQUEST_TIMEOUT    = 900 # 15 min
 end


### PR DESCRIPTION
Use more meaningful term smartstate in Amazon environments. 