### PR TITLE
update aws-sdk gem to v3

### DIFF
--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) } - %w[console setup]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk",               "~>2.9.7"
+  spec.add_dependency "aws-sdk",               "~> 3.0"
   spec.add_dependency "log_decorator",         "~> 0.1"
   spec.add_dependency "manageiq-gems-pending", "~> 0"
   spec.add_dependency "manageiq-smartstate",   "~> 0.2"

--- a/spec/aws_ssa_commons.rb
+++ b/spec/aws_ssa_commons.rb
@@ -1,3 +1,6 @@
+require 'aws-sdk-sqs'
+require 'aws-sdk-s3'
+
 def config_aws_client_stub
   Aws.config[:sqs] = {
     :stub_responses => {


### PR DESCRIPTION
This is a part of global update `aws-sdk` gem to `v3`

Together with:
- https://github.com/ManageIQ/manageiq-providers-amazon/pull/488
- https://github.com/ManageIQ/manageiq-gems-pending/pull/374

It should fix https://github.com/ManageIQ/manageiq-providers-amazon/issues/465