### PR TITLE
Replaced YAML load with safe_load

### DIFF
--- a/bin/amazon_ssa_agent
+++ b/bin/amazon_ssa_agent
@@ -39,7 +39,7 @@ OptionParser.new do |opts|
 end
 
 require 'yaml'
-aws_args = YAML.load(File.read("#{work_dir}/config.yml"), :safe => true)
+aws_args = YAML.safe_load(File.read("#{work_dir}/config.yml"))
 
 # Logging must be set up very early because log_decorator will apply to
 # all classes after it's required.


### PR DESCRIPTION
Ruby 2.5 doesn't support `YAML.load(content, :safe => true)` anymore, replaced it with `YAML.safe_load(content)`

https://bugzilla.redhat.com/show_bug.cgi?id=1739188