### PR TITLE
Fixed code climate errors

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -33,6 +33,7 @@ engines:
   rubocop:
     enabled: true
     config: '.rubocop_cc.yml'
+    channel: 'rubocop-0-69'
 prepare:
   fetch:
   - url: "https://raw.githubusercontent.com/ManageIQ/guides/master/.rubocop_base.yml"


### PR DESCRIPTION
Set rubocop version to 0.69, to fix the code climate errors.