### PR TITLE
update aws-sdk gem to v3

### DIFF
--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) } - %w[console setup]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk-sqs",           "~> 1.22.0"
-  spec.add_dependency "aws-sdk-s3",            "~> 1.49.0"
+  spec.add_dependency "aws-sdk-sqs",           "~> 1.0"
+  spec.add_dependency "aws-sdk-ec2",           "~> 1.0"
+  spec.add_dependency "aws-sdk-s3",            "~> 1.0"
   spec.add_dependency "log_decorator",         "~> 0.1"
   spec.add_dependency "manageiq-gems-pending", "~> 0"
   spec.add_dependency "manageiq-smartstate",   "~> 0.2"

--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) } - %w[console setup]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk",               "~>2.9.7"
+  spec.add_dependency "aws-sdk",               "~> 3.0"
   spec.add_dependency "log_decorator",         "~> 0.1"
   spec.add_dependency "manageiq-gems-pending", "~> 0"
   spec.add_dependency "manageiq-smartstate",   "~> 0.2"

--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) } - %w[console setup]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "aws-sdk",               "~> 3.0"
+  spec.add_dependency "aws-sdk-sqs",           "~> 1.22.0"
+  spec.add_dependency "aws-sdk-s3",            "~> 1.49.0"
   spec.add_dependency "log_decorator",         "~> 0.1"
   spec.add_dependency "manageiq-gems-pending", "~> 0"
   spec.add_dependency "manageiq-smartstate",   "~> 0.2"

--- a/bin/amazon_ssa_agent
+++ b/bin/amazon_ssa_agent
@@ -59,7 +59,9 @@ require 'log_decorator'
 include LogDecorator::Logging
 LogDecorator.logger = $log
 
-require 'aws-sdk'
+require 'aws-sdk-ec2'
+require 'aws-sdk-sqs'
+require 'aws-sdk-s3'
 require 'amazon_ssa_support'
 require 'manageiq-gems-pending'
 

--- a/lib/amazon_ssa_support/ssa_common.rb
+++ b/lib/amazon_ssa_support/ssa_common.rb
@@ -1,4 +1,4 @@
-require 'aws-sdk'
+require 'aws-sdk-s3'
 require 'logger'
 
 # Constants and methods

--- a/lib/amazon_ssa_support/ssa_heartbeat.rb
+++ b/lib/amazon_ssa_support/ssa_heartbeat.rb
@@ -1,5 +1,5 @@
 require 'yaml'
-require 'aws-sdk'
+require 'aws-sdk-s3'
 
 require 'log_decorator'
 require_relative 'ssa_common'

--- a/lib/amazon_ssa_support/ssa_queue.rb
+++ b/lib/amazon_ssa_support/ssa_queue.rb
@@ -1,5 +1,5 @@
 require 'yaml'
-require 'aws-sdk'
+require 'aws-sdk-sqs'
 require 'active_support/time_with_zone'
 
 require_relative 'ssa_common'

--- a/lib/amazon_ssa_support/ssa_queue_extractor.rb
+++ b/lib/amazon_ssa_support/ssa_queue_extractor.rb
@@ -1,5 +1,5 @@
 require 'yaml'
-require 'aws-sdk'
+require 'aws-sdk-ec2'
 
 require_relative 'miq_ec2_vm/miq_ec2_vm'
 require_relative 'ssa_queue'

--- a/spec/aws_ssa_commons.rb
+++ b/spec/aws_ssa_commons.rb
@@ -1,3 +1,6 @@
+require 'aws-sdk-sqs'
+require 'aws-sdk-s3'
+
 def config_aws_client_stub
   Aws.config[:sqs] = {
     :stub_responses => {

--- a/spec/miq_ec2_vm/miq_ec2_ebs_instance_spec.rb
+++ b/spec/miq_ec2_vm/miq_ec2_ebs_instance_spec.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk'
-
 require_relative '../spec_helper'
 require_relative '../aws_ssa_commons'
 

--- a/spec/miq_ec2_vm/miq_ec2_vm_spec.rb
+++ b/spec/miq_ec2_vm/miq_ec2_vm_spec.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk'
-
 require_relative '../spec_helper'
 require_relative '../aws_ssa_commons'
 

--- a/spec/ssa_bucket_spec.rb
+++ b/spec/ssa_bucket_spec.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk'
-
 require_relative 'spec_helper'
 require_relative 'aws_ssa_commons'
 

--- a/spec/ssa_heartbeat_spec.rb
+++ b/spec/ssa_heartbeat_spec.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk'
-
 require_relative 'spec_helper'
 require_relative 'aws_ssa_commons'
 

--- a/spec/ssa_queue_extractor_spec.rb
+++ b/spec/ssa_queue_extractor_spec.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk'
-
 require_relative 'spec_helper'
 require_relative 'aws_ssa_commons'
 

--- a/spec/ssa_queue_spec.rb
+++ b/spec/ssa_queue_spec.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk'
-
 require_relative 'spec_helper'
 require_relative 'aws_ssa_commons'
 


### PR DESCRIPTION
This is a part of global update `aws-sdk` gem to `v3`

Together with:
- https://github.com/ManageIQ/manageiq-providers-amazon/pull/488
- https://github.com/ManageIQ/manageiq/pull/19411
- https://github.com/ManageIQ/manageiq-gems-pending/pull/449

It should fix https://github.com/ManageIQ/manageiq-providers-amazon/issues/465