### PR TITLE
[HAMMER] Update git branch for gems-pending

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in amazon_ssa_support.gemspec
 gemspec
 
-gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
+gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "hammer"
 
 group :test do
   gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"


### PR DESCRIPTION
Travis is failing because we're using gems-pending 'master' branch.

https://travis-ci.org/ManageIQ/amazon_ssa_support/jobs/601311075

```
Bundler could not find compatible versions for gem "aws-sdk":
  In Gemfile:
    amazon_ssa_support was resolved to 0.1.0, which depends on
      aws-sdk (~> 2.9.7)
    manageiq-gems-pending was resolved to 0.1.0, which depends on
      aws-sdk (~> 3.0.1)
```