### PR TITLE
List dependency on handsoap from rubygems.manageiq.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,7 @@
+source 'http://rubygems.manageiq.org'
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in amazon_ssa_support.gemspec
 gemspec
 
 gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"
-
-group :test do
-  gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"
-end

--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -28,8 +28,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency "manageiq-smartstate",   "~> 0.2"
 
   spec.add_development_dependency "bundler"
+  spec.add_development_dependency "handsoap", "=  0.2.5.5"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rspec",    "~> 3.0"
 
   spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
Changed to use rubygems.manageiq.org to match manageiq-gems-pending. Copied the changes from https://github.com/ManageIQ/manageiq-gems-pending/pull/456.

Travis failure:

https://travis-ci.org/ManageIQ/amazon_ssa_support/jobs/633595850

```
Bundler could not find compatible versions for gem "handsoap":
  In Gemfile:
    handsoap (~> 0.2.5)
    manageiq-gems-pending was resolved to 0.1.0, which depends on
      handsoap (= 0.2.5.5)
Could not find gem 'handsoap (= 0.2.5.5)', which is required by gem
'manageiq-gems-pending', in any of the relevant sources:
  https://github.com/ManageIQ/handsoap.git (at v0.2.5-5@b1247a7)
```
@roliveri please review

cc @bdunne 