### PR TITLE
Test with ruby 2.6.6 on Kasparov\nBuilds of appliances and pods at Kaspa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.5.8
 - 2.6.6
 sudo: false
 before_install: gem install bundler -v 1.13.0


### PR DESCRIPTION
Test with ruby 2.6.6 on Kasparov\nBuilds of appliances and pods at Kaspa