### PR TITLE
drop sudo:false

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ cache: bundler
 rvm:
 - 2.5.8
 - 2.6.6
-sudo: false
 before_install: gem install bundler -v 1.13.0
 after_script: bundle exec codeclimate-test-reporter
 notifications:


### PR DESCRIPTION
we can get rid of sudo: false per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration