### PR TITLE
Lockdown tests to use ruby 2.6.6 per ManageIQ/manageiq#19678

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.5.8
 - 2.6.6
 before_install: gem install bundler -v 1.13.0
 after_script: bundle exec codeclimate-test-reporter


### PR DESCRIPTION
Lockdown tests to use ruby 2.6.6 per ManageIQ/manageiq#19678