### PR TITLE
Drop log_decorator

### DIFF
--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "aws-sdk-sqs",           "~> 1.0"
   spec.add_dependency "aws-sdk-ec2",           "~> 1.0"
   spec.add_dependency "aws-sdk-s3",            "~> 1.0"
-  spec.add_dependency "log_decorator",         "~> 0.1"
   spec.add_dependency "manageiq-gems-pending", "~> 0"
   spec.add_dependency "manageiq-smartstate",   "~> 0.2"
 

--- a/bin/amazon_ssa_agent
+++ b/bin/amazon_ssa_agent
@@ -41,8 +41,6 @@ end
 require 'yaml'
 aws_args = YAML.load(File.read("#{work_dir}/config.yml"))
 
-# Logging must be set up very early because log_decorator will apply to
-# all classes after it's required.
 require 'amazon_ssa_support/rolling_s3_logger'
 log_filename  = File.join(work_dir, "extract.log")
 log_max_size  = (log_max_size || aws_args[:log_max_size] || 1_048_576).to_i
@@ -53,11 +51,6 @@ at_exit do
   $log.roll
   Dir.glob("#{log_filename}*").each { |f| File.delete(f) }
 end
-
-require 'log_decorator'
-::Module.include(LogDecorator::Logging::ClassMethods)
-include LogDecorator::Logging
-LogDecorator.logger = $log
 
 require 'aws-sdk-ec2'
 require 'aws-sdk-sqs'
@@ -99,7 +92,7 @@ begin
   #
   eqe = AmazonSsaSupport::SsaQueueExtractor.new(aws_args)
 
-  _log.info("Agent starts to process requests ...")
+  $log.info("Agent starts to process requests ...")
 
   begin
     exit_code = eqe.extract_loop(timeout)
@@ -109,19 +102,19 @@ begin
     #
     case exit_code
     when :exit
-      _log.info("Exiting")
+      $log.info("Exiting")
       ehb.stop_heartbeat_loop
     when :reboot
-      _log.info("Rebooting")
+      $log.info("Rebooting")
       ehb.stop_heartbeat_loop
       aws_args[:ec2].instance(extractor_id).stop
     when :shutdown
-      _log.info("Shutting down")
+      $log.info("Shutting down")
       ehb.stop_heartbeat_loop
       aws_args[:ec2].instance(extractor_id).stop
     end
   rescue => err
-    _log.error("ERROR: #{err}")
-    _log.error(err.backtrace.join("\n"))
+    $log.error("ERROR: #{err}")
+    $log.error(err.backtrace.join("\n"))
   end
 end

--- a/lib/amazon_ssa_support.rb
+++ b/lib/amazon_ssa_support.rb
@@ -1,8 +1,7 @@
 require 'manageiq-smartstate'
 
-require 'log_decorator'
-
 require 'amazon_ssa_support/version'
+require 'amazon_ssa_support/logging'
 require 'amazon_ssa_support/ssa_common'
 require 'amazon_ssa_support/instance_metadata'
 require 'amazon_ssa_support/ssa_bucket.rb'

--- a/lib/amazon_ssa_support/instance_metadata.rb
+++ b/lib/amazon_ssa_support/instance_metadata.rb
@@ -2,7 +2,7 @@ require 'httpclient'
 
 module AmazonSsaSupport
   class InstanceMetadata
-    include LogDecorator::Logging
+    include Logging
 
     def initialize(version = 'latest')
       @base_url     = 'http://169.254.169.254/'

--- a/lib/amazon_ssa_support/logging.rb
+++ b/lib/amazon_ssa_support/logging.rb
@@ -1,0 +1,22 @@
+module AmazonSsaSupport
+  class << self
+    attr_writer :logger
+  end
+
+  def self.logger
+    @logger ||= $log || begin
+      require 'logger'
+      Logger.new($stdout)
+    end
+  end
+
+  module Logging
+    def self.included(base)
+      base.extend(self)
+    end
+
+    def _log
+      AmazonSsaSupport.logger
+    end
+  end
+end

--- a/lib/amazon_ssa_support/miq_ec2_vm/miq_ec2_ebs_vmbase.rb
+++ b/lib/amazon_ssa_support/miq_ec2_vm/miq_ec2_ebs_vmbase.rb
@@ -3,7 +3,7 @@ require_relative '../instance_metadata'
 
 module AmazonSsaSupport
   class MiqEC2EbsVmBase < MiqEC2VmBase
-    include LogDecorator::Logging
+    include Logging
 
     attr_reader :volumes
 

--- a/lib/amazon_ssa_support/ssa_bucket.rb
+++ b/lib/amazon_ssa_support/ssa_bucket.rb
@@ -2,7 +2,7 @@ require_relative 'ssa_common'
 
 module AmazonSsaSupport
   module SsaBucket
-    include LogDecorator::Logging
+    include Logging
 
     def self.get(arg_hash)
       raise ArgumentError, "Bucket and region must be specified." unless arg_hash[:ssa_bucket] && arg_hash[:region]

--- a/lib/amazon_ssa_support/ssa_heartbeat.rb
+++ b/lib/amazon_ssa_support/ssa_heartbeat.rb
@@ -1,13 +1,12 @@
 require 'yaml'
 require 'aws-sdk-s3'
 
-require 'log_decorator'
 require_relative 'ssa_common'
 require_relative 'ssa_bucket'
 
 module AmazonSsaSupport
   class SsaHeartbeat
-    include LogDecorator::Logging
+    include Logging
 
     attr_reader :extractor_id, :heartbeat_prefix
     attr_reader :heartbeat_thread, :heartbeat_interval

--- a/lib/amazon_ssa_support/ssa_queue.rb
+++ b/lib/amazon_ssa_support/ssa_queue.rb
@@ -7,7 +7,7 @@ require_relative 'ssa_bucket'
 
 module AmazonSsaSupport
   class SsaQueue
-    include LogDecorator::Logging
+    include Logging
 
     attr_reader :ssa_bucket_name, :ssa_region, :request_queue_name, :reply_queue_name, :reply_bucket_name, :extractor_id
     attr_reader :request_queue, :reply_queue, :reply_bucket, :reply_prefix, :sqs

--- a/lib/amazon_ssa_support/ssa_queue_extractor.rb
+++ b/lib/amazon_ssa_support/ssa_queue_extractor.rb
@@ -6,7 +6,7 @@ require_relative 'ssa_queue'
 
 module AmazonSsaSupport
   class SsaQueueExtractor
-    include LogDecorator::Logging
+    include Logging
 
     CATEGORIES = %w(accounts services software system).freeze
     attr_reader :my_instance, :ssaq

--- a/spec/miq_ec2_vm/miq_ec2_ebs_instance_spec.rb
+++ b/spec/miq_ec2_vm/miq_ec2_ebs_instance_spec.rb
@@ -1,9 +1,6 @@
 require_relative '../spec_helper'
 require_relative '../aws_ssa_commons'
 
-::Module.include(LogDecorator::Logging::ClassMethods)
-include LogDecorator::Logging
-
 describe AmazonSsaSupport::MiqEC2EbsInstance do
   before :each do
     @eb2_obj = mocked_ebs_instance('i-mocked-1')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,9 +3,6 @@ if ENV['CI']
   SimpleCov.start
 end
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
-
-require 'bundler/setup'
 require 'amazon_ssa_support'
 
 RSpec.configure do |config|

--- a/spec/ssa_heartbeat_spec.rb
+++ b/spec/ssa_heartbeat_spec.rb
@@ -1,9 +1,6 @@
 require_relative 'spec_helper'
 require_relative 'aws_ssa_commons'
 
-::Module.include(LogDecorator::Logging::ClassMethods)
-include LogDecorator::Logging
-
 describe AmazonSsaSupport::SsaHeartbeat do
   before(:each) do
     Aws.config[:s3] = {

--- a/spec/ssa_queue_spec.rb
+++ b/spec/ssa_queue_spec.rb
@@ -1,9 +1,6 @@
 require_relative 'spec_helper'
 require_relative 'aws_ssa_commons'
 
-::Module.include(LogDecorator::Logging::ClassMethods)
-include LogDecorator::Logging
-
 describe AmazonSsaSupport::SsaQueue do
   before(:each) do
     config_aws_client_stub


### PR DESCRIPTION
The log_decorator gem is only used by the one project in the ManageIQ
org with all other projects now archived.  We don't really need the
functionality it provides, and this simplifies the logging experience

@agrare Please review.