### PR TITLE
drop references to dev library handsoap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,4 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in amazon_ssa_support.gemspec
 gemspec
 
-gem "handsoap", "=0.2.5.5", :require => false, :source => "http://rubygems.manageiq.org"
 gem "manageiq-gems-pending", :git => "https://github.com/ManageIQ/manageiq-gems-pending.git", :branch => "master"

--- a/amazon_ssa_support.gemspec
+++ b/amazon_ssa_support.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "manageiq-smartstate",   "~> 0.2"
 
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "handsoap",       "= 0.2.5.5"
   spec.add_development_dependency "manageiq-style"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec",          "~> 3.0"


### PR DESCRIPTION
the manageiq rubygems reference is failing the build for today.
But that failure is a temporary failure.
Leaving handsoap in here is probably fine.

But trying to remove handsoap from all projects so seems like a good opportunity.