### PR TITLE
Use namespaced gem require instead of hyphenated name

### DIFF
--- a/bin/amazon_ssa_agent
+++ b/bin/amazon_ssa_agent
@@ -56,7 +56,7 @@ require 'aws-sdk-ec2'
 require 'aws-sdk-sqs'
 require 'aws-sdk-s3'
 require 'amazon_ssa_support'
-require 'manageiq-gems-pending'
+require 'manageiq/gems/pending'
 
 begin
   #


### PR DESCRIPTION
Both work but the namespaced name is more friendly to zeitwerk in the future.

Related: https://github.com/ManageIQ/manageiq/issues/22000