### PR TITLE
Fix name error loading gem-pending files without the zeitwerk loader

### DIFF
--- a/lib/amazon_ssa_support/miq_ec2_vm/miq_ec2_vmbase.rb
+++ b/lib/amazon_ssa_support/miq_ec2_vm/miq_ec2_vmbase.rb
@@ -1,3 +1,4 @@
+require 'manageiq/gems/pending'
 require 'MiqVm/MiqVm'
 
 module AmazonSsaSupport


### PR DESCRIPTION
Similar to https://github.com/ManageIQ/manageiq-smartstate/pull/177

Require the gem before requiring libraries inside it

We need to load the zeitwerk loader to retain the autoloading mechanics or the rules around loading constants that don't live in standard locations.