### PR TITLE
Require active_support/deprecation and active_support/deprecator

### DIFF
--- a/lib/amazon_ssa_support/ssa_queue.rb
+++ b/lib/amazon_ssa_support/ssa_queue.rb
@@ -1,5 +1,7 @@
 require 'yaml'
 require 'aws-sdk-sqs'
+require 'active_support/deprecation'
+require 'active_support/deprecator'
 require 'active_support/time_with_zone'
 
 require_relative 'ssa_common'


### PR DESCRIPTION
ActiveSupport Array Conversions uses `ActiveSupport.deprecator` without requiring it: https://github.com/rails/rails/blob/v7.1.4/activesupport/lib/active_support/core_ext/array/conversions.rb#L108

Leading to:
```
 An error occurred while loading spec_helper.
Failure/Error: require 'active_support/time_with_zone'

NoMethodError:
  undefined method `deprecator' for ActiveSupport:Module
```

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
